### PR TITLE
Fixed 'Rebuild Link'

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -457,23 +457,10 @@ function addRebuildSlugButton(titleWrap) {
 
     $(subBtn).click(function(e) {
         e.preventDefault();
-        $("#editable-post-name").click();
-
-        var int1 = setInterval(function(){
-            var slugInput = $('#new-post-slug');
-            if (slugInput.length) {
-                slugInput.val("");
-                clearInterval(int1);
-
-                var int2 = setInterval(function(){
-                    var saveButton = $("#edit-slug-buttons a.save.button.button-small");
-                    if (saveButton.length) {
-                        saveButton[0].click();
-                    }
-                    clearInterval(int2);
-                }, 100);
-            }
-        }, 100);
+        $("button.edit-slug").click();
+        var title = $("input[name='post_title']").val();
+        $("#new-post-slug").val(title);
+        $("button.save").click();
     });
 
     $('#edit-slug-box').parent().append(subBtn);


### PR DESCRIPTION
The recent WP upgrade broke the "Rebuild Link" button. Clicking it opens a preview of the post. This should fix it.
