### PR TITLE
Refactored editor pane code

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -149,6 +149,7 @@
 }
 
 .post-info-table {
+  display: table;
   width: 100%;
   border-spacing: 0;
   border: none;

--- a/fragments/info-row.html
+++ b/fragments/info-row.html
@@ -1,0 +1,8 @@
+<table class="post-info-table">
+  <tbody>
+    <tr class="proofreader-main-row">
+      <td colspan="2" class="bandaid-message">
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "WP Band Aid",
   "description": "This extension is for internal use at SitePoint. It makes using the WP back end a bit easier.",
-  "version": "0.13.4",
+  "version": "0.13.5",
 
   "background": {
     "scripts": [

--- a/scripts/wordpress/newPostPage.js
+++ b/scripts/wordpress/newPostPage.js
@@ -16,6 +16,7 @@ chrome.extension.sendMessage({}, function (response) {
       TitleArea.init();
 
       // Editor pane
+      // Adds status bar
       // Checks for presence of [author_more] tag
       // Checks for relative links
       EditorPane.init();


### PR DESCRIPTION
- Moved DOM elements into template
- Tuned regex to match links using single quotes
- No longer querying the DOM in setInterval callback
- Dynamically generated messages no longer overflow editor field
- Removed `checkFor` object and accompanying loop, as it was only being used to check for a single string and no patterns. Can easily be readded when needed.
